### PR TITLE
Plan 9 port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ CFLAGS += -Wall
 CFLAGS += -O3
 CFLAGS += -g
 
+LDFLAGS += -lm
+
 TANGLED=\
 dsp/bigverb.c dsp/bigverb.h \
 dsp/bitnoise.c dsp/bitnoise.h \
@@ -166,7 +168,7 @@ libsndkit.a: $(OBJ)
 
 sndkit: main.o $(OBJ)
 	@echo "Building $@"
-	@$(CC) $(CFLAGS) $^ -o $@
+	@$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
 install: libsndkit.a sndkit
 	mkdir -p /usr/local/lib

--- a/core.org
+++ b/core.org
@@ -29,6 +29,13 @@ Registers are for more persitently used values.
 #endif
 <<macros>>
 <<funcdefs>>
+
+#ifdef __plan9__
+#pragma incomplete sk_core
+#pragma incomplete sk_stack
+#pragma incomplete sk_regtbl
+#pragma incomplete sk_table
+#endif
 #endif
 #+END_SRC
 

--- a/dsp/chorus.org
+++ b/dsp/chorus.org
@@ -55,6 +55,10 @@ expose the =sk_chorus= struct.
 #endif
 
 <<funcdefs>>
+
+#ifdef __plan9__
+#pragma incomplete sk_chorus
+#endif
 #endif
 #+END_SRC
 

--- a/lil/lil.h
+++ b/lil/lil.h
@@ -77,6 +77,14 @@ typedef struct _lil_var_t* lil_var_t;
 typedef struct _lil_env_t* lil_env_t;
 typedef struct _lil_list_t* lil_list_t;
 typedef struct _lil_t* lil_t;
+#ifdef __plan9__
+#pragma incomplete struct _lil_value_t;
+#pragma incomplete struct _lil_func_t;
+#pragma incomplete struct _lil_var_t;
+#pragma incomplete struct _lil_env_t;
+#pragma incomplete struct _lil_list_t;
+#pragma incomplete struct _lil_t;
+#endif
 typedef LILCALLBACK lil_value_t (*lil_func_proc_t)(lil_t lil, size_t argc, lil_value_t* argv);
 typedef LILCALLBACK void (*lil_exit_callback_proc_t)(lil_t lil, lil_value_t arg);
 typedef LILCALLBACK void (*lil_write_callback_proc_t)(lil_t lil, const char* msg);

--- a/lil/lil_main.c
+++ b/lil/lil_main.c
@@ -48,7 +48,7 @@ static LILCALLBACK void do_exit(lil_t lil, lil_value_t val)
 
 static char* do_system(size_t argc, char** argv)
 {
-    #if defined(WIN32) || defined(WATCOMC)
+    #if defined(WIN32) || defined(WATCOMC) || defined(__plan9__)
     return NULL;
     #else
     char* cmd = NULL;

--- a/mkfile
+++ b/mkfile
@@ -1,0 +1,180 @@
+</$objtype/mkfile
+
+TARG=sndkit
+PROG=${TARG:%=$O.%}
+BIN=/$objtype/bin/audio
+CFLAGS=$CFLAGS -p -I. -Inodes -Ipatchwerk -I/sys/include/npe -D__plan9__ -Dwchar_t=char -DDRWAV_HAS_WFOPEN -D_wfopen=fopen
+WORGLE=`{pwd}/worgle/worgle.$cputype
+
+HFILES=\
+	lil/lil.h\
+
+ORGFILES=\
+	core.c\
+	dsp/bezier.c\
+	dsp/bigverb.c\
+	dsp/biramp.c\
+	dsp/bitnoise.c\
+	dsp/bitosc.c\
+	dsp/chaosnoise.c\
+	dsp/chorus.c\
+	dsp/dcblocker.c\
+	dsp/env.c\
+	dsp/expmap.c\
+	dsp/expon.c\
+	dsp/fmpair.c\
+	dsp/gen.c\
+	dsp/metro.c\
+	dsp/modalres.c\
+	dsp/mtof.c\
+	dsp/osc.c\
+	dsp/oscf.c\
+	dsp/peakeq.c\
+	dsp/phasewarp.c\
+	dsp/phasor.c\
+	dsp/phsclk.c\
+	dsp/rephasor.c\
+	dsp/rline.c\
+	dsp/scale.c\
+	dsp/smoother.c\
+	dsp/swell.c\
+	dsp/valp1.c\
+	dsp/vardelay.c\
+
+OFILES=\
+	${ORGFILES:%.c=%.$O}\
+	main.$O\
+	lil/lil.$O\
+	lil/lil_main.$O\
+	nodes/loader.$O\
+	nodes/sklil.$O\
+	nodes/arith/arith.$O\
+	nodes/arith/l_arith.$O\
+	nodes/bezier/bezier.$O\
+	nodes/bezier/l_bezier.$O\
+	nodes/bigverb/bigverb.$O\
+	nodes/bigverb/l_bigverb.$O\
+	nodes/biramp/biramp.$O\
+	nodes/biramp/l_biramp.$O\
+	nodes/bitnoise/bitnoise.$O\
+	nodes/bitnoise/l_bitnoise.$O\
+	nodes/bitosc/bitosc.$O\
+	nodes/bitosc/l_bitosc.$O\
+	nodes/buffer/buffer.$O\
+	nodes/chaosnoise/chaosnoise.$O\
+	nodes/chaosnoise/l_chaosnoise.$O\
+	nodes/chorus/chorus.$O\
+	nodes/chorus/l_chorus.$O\
+	nodes/dcblocker/dcblocker.$O\
+	nodes/dcblocker/l_dcblocker.$O\
+	nodes/env/env.$O\
+	nodes/env/l_env.$O\
+	nodes/expmap/expmap.$O\
+	nodes/expmap/l_expmap.$O\
+	nodes/expon/expon.$O\
+	nodes/expon/l_expon.$O\
+	nodes/fmpair/fmpair.$O\
+	nodes/fmpair/l_fmpair.$O\
+	nodes/gensine/gensine.$O\
+	nodes/gensine/l_gensine.$O\
+	nodes/metro/l_metro.$O\
+	nodes/metro/metro.$O\
+	nodes/modalres/l_modalres.$O\
+	nodes/modalres/modalres.$O\
+	nodes/mtof/l_mtof.$O\
+	nodes/mtof/mtof.$O\
+	nodes/osc/l_osc.$O\
+	nodes/osc/osc.$O\
+	nodes/oscf/l_oscf.$O\
+	nodes/oscf/oscf.$O\
+	nodes/peakeq/l_peakeq.$O\
+	nodes/peakeq/peakeq.$O\
+	nodes/phasewarp/l_phasewarp.$O\
+	nodes/phasewarp/phasewarp.$O\
+	nodes/phasor/l_phasor.$O\
+	nodes/phasor/phasor.$O\
+	nodes/reg/reg.$O\
+	nodes/rephasor/l_rephasor.$O\
+	nodes/rephasor/rephasor.$O\
+	nodes/rline/l_rline.$O\
+	nodes/rline/rline.$O\
+	nodes/scale/l_scale.$O\
+	nodes/scale/scale.$O\
+	nodes/sine/l_sine.$O\
+	nodes/sine/sine.$O\
+	nodes/smoother/l_smoother.$O\
+	nodes/smoother/smoother.$O\
+	nodes/tabnew/tabnew.$O\
+	nodes/valp1/l_valp1.$O\
+	nodes/valp1/valp1.$O\
+	nodes/vardelay/l_vardelay.$O\
+	nodes/vardelay/vardelay.$O\
+	nodes/wav/l_wavin.$O\
+	nodes/wav/l_wavout.$O\
+	nodes/wav/wavin.$O\
+	nodes/wav/wavout.$O\
+	patchwerk/patchwerk.$O\
+
+CLEANFILES=$OFILES $PROG $ORGFILES ${ORGFILES:%.c=%.h}
+
+default:V: all
+
+all:V: $PROG
+
+install:V:
+	for (i in $TARG)
+		mk $MKFLAGS $i.install
+
+installall:V:
+	for(objtype in $CPUS)
+		mk $MKFLAGS install
+
+installall:V:
+	for(objtype in $CPUS)
+		mk install
+
+allall:V:
+	for(objtype in $CPUS)
+		mk all
+
+nuke:V: clean
+	rm -f *.acid
+
+clean:V:
+	rm -f *.[$OS] [$OS].out y.tab.? lex.yy.c y.debug y.output $CLEANFILES
+	cd worgle
+	mk clean
+	cd ..
+
+%.install:V: $BIN/%
+
+$BIN/%: $O.%
+	cp $prereq $BIN/$stem
+
+$O.sndkit: $OFILES $LIB
+	$LD $LDFLAGS -o $target $prereq
+
+([^/]*)/(.*)\.$O:R: core.h \1/\2\.c
+	$CC $CFLAGS -o $target $stem1/$stem2.c
+
+([^/]*)\.$O:R: \1\.c
+	$CC $CFLAGS -o $target $stem1.c
+
+worgle:V: $WORGLE
+
+$WORGLE:
+	cd worgle
+	@{objtype=$cputype mk}
+	cd ..
+
+core.$O: core.c core.h
+
+dsp/%.$O: dsp/%.c dsp/%.h
+
+core.c core.h:Q: $WORGLE
+	$WORGLE -g -Werror core.org
+
+dsp/%.c dsp/%.h:Q: dsp/%.org $WORGLE
+	cd dsp
+	$WORGLE -g -Werror $stem.org
+	cd ..

--- a/nodes/buffer/buffer.c
+++ b/nodes/buffer/buffer.c
@@ -34,7 +34,7 @@ static lil_value_t unhold(lil_t lil, size_t argc, lil_value_t *argv)
     return NULL;
 }
 
-static lil_value_t dup(lil_t lil, size_t argc, lil_value_t *argv)
+static lil_value_t lil_dup(lil_t lil, size_t argc, lil_value_t *argv)
 {
     sk_core *core;
     int rc;
@@ -80,7 +80,7 @@ void sklil_load_buffer(lil_t lil)
 {
     lil_register(lil, "hold", hold);
     lil_register(lil, "unhold", unhold);
-    lil_register(lil, "dup", dup);
+    lil_register(lil, "dup", lil_dup);
     lil_register(lil, "drop", drop);
     lil_register(lil, "swap", swap);
 }

--- a/nodes/wav/dr_wav.h
+++ b/nodes/wav/dr_wav.h
@@ -183,6 +183,12 @@ typedef drwav_uint32            drwav_bool32;
 #define DRWAV_TRUE              1
 #define DRWAV_FALSE             0
 
+#ifdef __plan9__
+#define WFMODE(m) m
+#else
+#define WFMODE(m) L##m
+#endif
+
 #if !defined(DRWAV_API)
     #if defined(DRWAV_DLL)
         #if defined(_WIN32)
@@ -3094,7 +3100,7 @@ DRWAV_API drwav_bool32 drwav_init_file_w(drwav* pWav, const wchar_t* filename, c
 DRWAV_API drwav_bool32 drwav_init_file_ex_w(drwav* pWav, const wchar_t* filename, drwav_chunk_proc onChunk, void* pChunkUserData, drwav_uint32 flags, const drwav_allocation_callbacks* pAllocationCallbacks)
 {
     FILE* pFile;
-    if (drwav_wfopen(&pFile, filename, L"rb", pAllocationCallbacks) != DRWAV_SUCCESS) {
+    if (drwav_wfopen(&pFile, filename, WFMODE("rb"), pAllocationCallbacks) != DRWAV_SUCCESS) {
         return DRWAV_FALSE;
     }
 
@@ -3136,7 +3142,7 @@ DRWAV_PRIVATE drwav_bool32 drwav_init_file_write__internal(drwav* pWav, const ch
 DRWAV_PRIVATE drwav_bool32 drwav_init_file_write_w__internal(drwav* pWav, const wchar_t* filename, const drwav_data_format* pFormat, drwav_uint64 totalSampleCount, drwav_bool32 isSequential, const drwav_allocation_callbacks* pAllocationCallbacks)
 {
     FILE* pFile;
-    if (drwav_wfopen(&pFile, filename, L"wb", pAllocationCallbacks) != DRWAV_SUCCESS) {
+    if (drwav_wfopen(&pFile, filename, WFMODE("wb"), pAllocationCallbacks) != DRWAV_SUCCESS) {
         return DRWAV_FALSE;
     }
 

--- a/patchwerk/patchwerk.c
+++ b/patchwerk/patchwerk.c
@@ -1572,7 +1572,7 @@ return patch->out;
 /*:281*//*283:*/
 #line 301 "./patch.w"
 
-size_t pw_patch_size()
+size_t pw_patch_size(void)
 {
 return sizeof(pw_patch);
 }

--- a/patchwerk/patchwerk.h
+++ b/patchwerk/patchwerk.h
@@ -6,7 +6,7 @@
 #include <stdio.h> 
 #include <stdarg.h>  
 /*6:*/
-#line 15 "./header.w"
+#line 23 "./header.w"
 
 #ifndef PWFLT
 #define PWFLT float
@@ -100,11 +100,11 @@ typedef int(*pw_mallocfun)(pw_patch*,size_t,void**);
 typedef int(*pw_freefun)(pw_patch*,void**);
 
 /*:393*/
-#line 24 "./header.w"
+#line 32 "./header.w"
 
 
 /*:6*//*7:*/
-#line 27 "./header.w"
+#line 35 "./header.w"
 
 /*55:*/
 #line 14 "./cable.w"
@@ -148,7 +148,7 @@ pw_buffer*buf;
 };
 
 /*:55*/
-#line 28 "./header.w"
+#line 36 "./header.w"
 
 #line 1 "./node.w"
 /*:7*//*22:*/
@@ -653,7 +653,7 @@ pw_cable*pw_patch_get_out(pw_patch*patch);
 /*:280*//*282:*/
 #line 298 "./patch.w"
 
-size_t pw_patch_size();
+size_t pw_patch_size(void);
 
 /*:282*//*285:*/
 #line 314 "./patch.w"
@@ -907,6 +907,14 @@ void pw_print_set(pw_patch*p,void(*print)(pw_patch*,const char*,va_list));
 /*:405*/
 #line 9 "./header.w"
 
+
+#ifdef __plan9__
+#pragma incomplete pw_buffer
+#pragma incomplete pw_patch
+#pragma incomplete pw_node
+#pragma incomplete pw_pointer
+#pragma incomplete pw_stack
+#endif
 #endif
 
 /*:5*/

--- a/worgle/mkfile
+++ b/worgle/mkfile
@@ -1,0 +1,24 @@
+</$objtype/mkfile
+
+TARGET=worgle.$cputype
+CFLAGS=$CFLAGS -DWORGLITE -p -I/sys/include/npe
+
+HFILES=\
+	parg.h\
+	worgle.h\
+	worgle_private.h\
+
+OFILES=\
+	parg.$O\
+	worgle.$O\
+
+$TARGET: $OFILES
+	$LD $LDFLAGS -o $target $prereq
+
+CLEANFILES=$TARGET
+
+</sys/src/cmd/mkone
+
+default:V: all
+
+all:V: $TARGET


### PR DESCRIPTION
Builds and runs on 9front/amd64. Only the final executable `sndkit` is built and installed (as `audio/sndkit`) for now, library isn't constructed.
Requires latest [npe](https://git.sr.ht/~ft/npe) to be installed.

`Makefile` change is unrelated: just makes it possible to build on Void Linux (and I assume on some other distros).