### PR TITLE
bigverb: make casts explicit

### DIFF
--- a/dsp/bigverb.org
+++ b/dsp/bigverb.org
@@ -207,7 +207,7 @@ SKFLT size;
 
 #+NAME: init_variables
 #+BEGIN_SRC c
-sk_bigverb_size(bv, 0.93);
+sk_bigverb_size(bv, 0.93f);
 #+END_SRC
 
 #+NAME: funcs
@@ -330,8 +330,8 @@ line.
 #+BEGIN_SRC c
 if (bv->pcutoff != bv->cutoff) {
     bv->pcutoff = bv->cutoff;
-    bv->filt = 2.0 - cos(bv->pcutoff * 2 * M_PI / bv->sr);
-    bv->filt = bv->filt - sqrt(bv->filt * bv->filt - 1.0);
+    bv->filt = (SKFLT) (2.0 - cos(bv->pcutoff * 2 * M_PI / bv->sr));
+    bv->filt = (SKFLT) (bv->filt - sqrt(bv->filt * bv->filt - 1.0));
 }
 #+END_SRC
 ** Calculating Resultant Junction Pressure Amount
@@ -441,8 +441,8 @@ static int get_delay_size(const struct bigverb_paramset *p, int sr);
 static int get_delay_size(const struct bigverb_paramset *p, int sr)
 {
     SKFLT sz;
-    sz = (SKFLT)p->delay/44100 + (p->drift * 0.0001) * 1.125;
-    return floor(16 + sz*sr);
+    sz = (SKFLT) (p->delay/44100.0 + (p->drift * 0.0001) * 1.125);
+    return (int) floor(16 + sz*sr);
 }
 #+END_SRC
 
@@ -592,10 +592,10 @@ Truncate (using integer cast).'
 #+NAME: setup_readpos
 #+BEGIN_SRC c
 readpos = ((SKFLT)p->delay / 44100);
-readpos += d->rng * (p->drift * 0.0001) / 32768.0;
+readpos += (SKFLT) (d->rng * (p->drift * 0.0001) / 32768.0);
 readpos = sz - (readpos * sr);
-d->irpos = floor(readpos);
-d->frpos = floor((readpos - d->irpos) * FRACSCALE);
+d->irpos = (int) floor(readpos);
+d->frpos = (int) floor((readpos - d->irpos) * FRACSCALE);
 #+END_SRC
 
 Create first random segments.
@@ -674,7 +674,7 @@ buffer size, wrap around.
 #+NAME: increment_write_position
 #+BEGIN_SRC c
 del->wpos++;
-if (del->wpos >= del->sz) del->wpos -= del->sz;
+if (del->wpos >= del->sz) del->wpos -= (int) del->sz;
 #+END_SRC
 
 Update the fractional read position. If the read position
@@ -695,7 +695,7 @@ If needed, update the read position with wrap-around.
 
 #+NAME: update_integer_read_position
 #+BEGIN_SRC c
-if (del->irpos >= del->sz) del->irpos -= del->sz;
+if (del->irpos >= del->sz) del->irpos -= (int) del->sz;
 #+END_SRC
 
 Normalize the fractional component so that it is in range
@@ -719,10 +719,10 @@ respectively, and will correspond to =x(n - 1)=, =x(n)=,
 #+BEGIN_SRC c
 {
     SKFLT tmp[2];
-    d = ((frac_norm * frac_norm) - 1) / 6.0;
-    tmp[0] = ((frac_norm + 1.0) * 0.5);
-    tmp[1] = 3.0 * d;
-    a = tmp[0] - 1.0 - d;
+    d = (SKFLT) (((frac_norm * frac_norm) - 1) / 6.0);
+    tmp[0] = (SKFLT) ((frac_norm + 1.0) * 0.5);
+    tmp[1] = 3.0f * d;
+    a = tmp[0] - 1.0f - d;
     c = tmp[0] - tmp[1];
     b = tmp[1] - frac_norm;
 }
@@ -750,11 +750,11 @@ and bounds checks.
     } else {
         int k;
         n--;
-        if (n < 0) n += del->sz;
+        if (n < 0) n += (int) del->sz;
         s[0] = x[n];
         for (k = 0; k < 3; k++) {
             n++;
-            if (n >= del->sz) n -= del->sz;
+            if (n >= del->sz) n -= (int) del->sz;
             s[k + 1] = x[n];
         }
     }
@@ -944,7 +944,7 @@ level, but perceptually it is completely identical.
 
 #+NAME: init_jitter
 #+BEGIN_SRC c
-d->maxcount = floor((sr / ((SKFLT)p->randfreq * 0.001)));
+d->maxcount = (int) floor((sr / ((SKFLT)p->randfreq * 0.001)));
 #+END_SRC
 
 #+NAME: reset_counter
@@ -970,7 +970,7 @@ and drift amount.
 
 #+NAME: compute_delay_values
 #+BEGIN_SRC c
-nxtdel = (d->rng * (d->drift * 0.0001) / 32768.0) + d->dels;
+nxtdel = (SKFLT) (d->rng * (d->drift * 0.0001) / 32768.0) + d->dels;
 #+END_SRC
 
 The delay time, in seconds (=dels=).
@@ -982,7 +982,7 @@ SKFLT dels;
 
 #+NAME: init_jitter
 #+BEGIN_SRC c
-d->dels = p->delay / 44100.0;
+d->dels = (SKFLT) (p->delay / 44100.0);
 #+END_SRC
 
 #+NAME: bigverb_delay
@@ -992,7 +992,7 @@ SKFLT drift;
 
 #+NAME: init_jitter
 #+BEGIN_SRC c
-d->drift = p->drift;
+d->drift = (SKFLT) p->drift;
 #+END_SRC
 
 The linear increment value is the difference between the current
@@ -1012,7 +1012,7 @@ fractional read.
 
 #+NAME: set_fractional_read
 #+BEGIN_SRC c
-d->inc = floor(inc * FRACSCALE);
+d->inc = (int) floor(inc * FRACSCALE);
 #+END_SRC
 
 #+NAME: funcs


### PR DESCRIPTION
MSVC is warning about some implicit casts with -W4. I figure it's better to be explicit about it.